### PR TITLE
Warnings not surfaced in errors

### DIFF
--- a/YaraSharp/Compiler.cpp
+++ b/YaraSharp/Compiler.cpp
@@ -98,8 +98,19 @@ namespace YaraSharp
 		UNREFERENCED_PARAMETER(ErrorLevel);
 		UNREFERENCED_PARAMETER(UserData);
 
-		auto msg = String::Format("{0} in line {1} in file: {2}",
-			marshal_as<String^>(Message), LineNumber,
+		String^ errorLevel;
+
+		if (ErrorLevel == YARA_ERROR_LEVEL_ERROR)
+		{
+			errorLevel = "ERROR";
+		}
+		else if (ErrorLevel == YARA_ERROR_LEVEL_WARNING)
+		{
+			errorLevel = "WARNING";
+		}
+
+		auto msg = String::Format("{0}: {1} on line {2} in file: {3}",
+			errorLevel, marshal_as<String^>(Message), LineNumber,
 			Filename ? marshal_as<String^>(Filename) : "[none]");
 
 		Errors->Add(msg);

--- a/YaraSharp/YaraSharp.cpp
+++ b/YaraSharp/YaraSharp.cpp
@@ -14,7 +14,7 @@ namespace YaraSharp
 		{
 			CCompiler^ TestCompiler = gcnew CCompiler(ExternalVariables);
 
-			if (TestCompiler->AddFile(FilePathList[i]))
+			if (TestCompiler->AddFile(FilePathList[i]) || TestCompiler->GetErrors()->Count > 0)
 			{
 				CompilationErrors->Add(FilePathList[i], TestCompiler->GetErrors());
 				FilePathList->Remove(FilePathList[i--]);
@@ -31,7 +31,7 @@ namespace YaraSharp
 			CCompiler^ TestCompiler = gcnew CCompiler(ExternalVariables);
 			for each (auto FilePath in FilePathList)
 			{
-				if (TestCompiler->AddFile(FilePath))
+				if (TestCompiler->AddFile(FilePath) || TestCompiler->GetErrors()->Count > 0)
 				{
 					CompilationErrors->Add(FilePath, TestCompiler->GetErrors());
 					FilePathList->Remove(FilePath);


### PR DESCRIPTION
The compiler callback method correctly receives warnings and errors and adds them to the Compilers Error list. However, If compiling rules that would only trigger warnings, the TestCompiler->AddRule() condition would never be true and thus prevent surfacing the warnings stored within the Compilers Errors list. I also modified the callback error message to easily differentiate between errors and warnings.