### PR TITLE
Even better warning handling

### DIFF
--- a/YaraSharp.sln
+++ b/YaraSharp.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YaraTest", "YaraTest\YaraTest.csproj", "{602143B0-7EA3-4843-8CEE-228BC66F0437}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YaraSharpUnitTests", "YaraSharpUnitTests\YaraSharpUnitTests.csproj", "{77A34A2C-411B-4958-B553-0151A11BA09B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,18 @@ Global
 		{602143B0-7EA3-4843-8CEE-228BC66F0437}.Release|x64.Build.0 = Release|Any CPU
 		{602143B0-7EA3-4843-8CEE-228BC66F0437}.Release|x86.ActiveCfg = Release|Any CPU
 		{602143B0-7EA3-4843-8CEE-228BC66F0437}.Release|x86.Build.0 = Release|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Debug|x64.Build.0 = Debug|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Debug|x86.Build.0 = Debug|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Release|x64.ActiveCfg = Release|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Release|x64.Build.0 = Release|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Release|x86.ActiveCfg = Release|Any CPU
+		{77A34A2C-411B-4958-B553-0151A11BA09B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/YaraSharp/Compiler.h
+++ b/YaraSharp/Compiler.h
@@ -15,8 +15,7 @@ namespace YaraSharp
 		~CCompiler();
 
 		CRules^ GetRules();
-		List<String^>^ GetErrors();
-		List<String^>^ GetWarnings();
+		List<String^>^ GetErrors(Boolean IncludeWarnings);
 		int AddFile(String^ FilePath);
 		void AddFiles(List<String^>^ FilePathList);
 

--- a/YaraSharp/Compiler.h
+++ b/YaraSharp/Compiler.h
@@ -8,7 +8,7 @@ namespace YaraSharp
 	public ref class CCompiler sealed
 	{
 		initonly YR_COMPILER* Compiler;
-		initonly List<String^>^ Errors;
+		initonly Dictionary<int, List<String^>^>^ Errors;
 
 	public:
 		CCompiler(Dictionary<String^, Object^>^ ExternalVariables);
@@ -16,6 +16,7 @@ namespace YaraSharp
 
 		CRules^ GetRules();
 		List<String^>^ GetErrors();
+		List<String^>^ GetWarnings();
 		int AddFile(String^ FilePath);
 		void AddFiles(List<String^>^ FilePathList);
 

--- a/YaraSharp/YaraSharp.cpp
+++ b/YaraSharp/YaraSharp.cpp
@@ -19,6 +19,10 @@ namespace YaraSharp
 				CompilationErrors->Add(FilePathList[i], TestCompiler->GetErrors());
 				FilePathList->Remove(FilePathList[i--]);
 			}
+			else if (TestCompiler->GetWarnings()->Count > 0)
+			{
+				CompilationErrors->Add(FilePathList[i], TestCompiler->GetWarnings());
+			}
 
 			delete TestCompiler;
 		}
@@ -40,6 +44,10 @@ namespace YaraSharp
 					//	New compiler must be created if we fail
 					delete TestCompiler;
 					break;
+				}
+				else if (TestCompiler->GetWarnings()->Count > 0)
+				{
+					CompilationErrors->Add(FilePath, TestCompiler->GetWarnings());
 				}
 			}
 		}

--- a/YaraSharp/YaraSharp.cpp
+++ b/YaraSharp/YaraSharp.cpp
@@ -13,7 +13,7 @@ namespace YaraSharp
 		{
 			CCompiler^ TestCompiler = gcnew CCompiler(ExternalVariables);
 
-			if (TestCompiler->AddFile(FilePathList[i]) || TestCompiler->GetErrors(false)->Count > 0)
+			if (TestCompiler->AddFile(FilePathList[i]))
 			{
 				if (CompilationErrors->ContainsKey(FilePathList[i]))
 				{

--- a/YaraSharpUnitTests/Properties/AssemblyInfo.cs
+++ b/YaraSharpUnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("YaraSharpUnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("YaraSharpUnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("77a34a2c-411b-4958-b553-0151a11ba09b")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/YaraSharpUnitTests/TestData/CheckWarningStillScans.txt
+++ b/YaraSharpUnitTests/TestData/CheckWarningStillScans.txt
@@ -1,0 +1,1 @@
+this is a slow regex

--- a/YaraSharpUnitTests/TestData/CheckWarningStillScans.yar
+++ b/YaraSharpUnitTests/TestData/CheckWarningStillScans.yar
@@ -1,0 +1,10 @@
+// This file contains a rule that should trigger a warning. This should not prevent scanning from being successful
+
+rule WarningRule
+{
+  strings:
+    $error_str = /this.+?is.+?a.+?slow.+?regex/
+
+  condition:
+    $error_str
+}

--- a/YaraSharpUnitTests/WarningsAndErrors.cs
+++ b/YaraSharpUnitTests/WarningsAndErrors.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using YaraSharp;
+
+namespace YaraSharpUnitTests
+{
+    [TestClass]
+    public class WarningsAndErrors
+    {
+        private static string BaseDirectory = Environment.CurrentDirectory;
+        private static string TestDataDirectory = Path.Combine(BaseDirectory, "TestData");
+
+        /// <summary>
+        /// Ensures warnings are correctly reported along with errors,
+        /// but does not prevent scanning from working
+        /// </summary>
+        [TestMethod]
+        public void CheckWarningsStillScan()
+        {
+            string inputFileBase = "CheckWarningStillScans";
+            string yaraRuleFile = Path.Combine(TestDataDirectory, $"{inputFileBase}.yar");
+            string yaraInputFile = Path.Combine(TestDataDirectory, $"{inputFileBase}.txt");
+
+            CYaraSharp yaraInstance = new CYaraSharp();
+
+            using (CContext context = new CContext())
+            {
+                using (CCompiler compiler = new CCompiler(null))
+                {
+                    compiler.AddFile(yaraRuleFile);
+                    List<string> compilerErrors = compiler.GetErrors(true);
+
+                    CScanner scanner = new CScanner(compiler.GetRules(), null);
+                    Assert.IsTrue(scanner.ScanFile(yaraInputFile).Any(r => r.Rule.Identifier == "WarningRule"));
+                }
+            }
+        }
+    }
+}

--- a/YaraSharpUnitTests/YaraSharpUnitTests.csproj
+++ b/YaraSharpUnitTests/YaraSharpUnitTests.csproj
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{77A34A2C-411B-4958-B553-0151A11BA09B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>YaraSharpUnitTests</RootNamespace>
+    <AssemblyName>YaraSharpUnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WarningsAndErrors.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="TestData\CheckWarningStillScans.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <None Include="packages.config" />
+    <Content Include="TestData\CheckWarningStillScans.yar">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\YaraSharp\YaraSharp.vcxproj">
+      <Project>{c005e3b9-2474-4fea-b5f4-7bb897111e8f}</Project>
+      <Name>YaraSharp</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/YaraSharpUnitTests/packages.config
+++ b/YaraSharpUnitTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
My previous changes made it so that any one compiling rules via the YaraSharp CompileFromFiles method treating warnings as errors, which is probably not desirable. I changed it so that errors and warnings are now stored in a Dictionary<int, List<String>>. The int is the Yara error level (0 = error, 1 = warning).

I removed the "sequential checks" from the CheckYaraRules method as I couldn't see any different functionality to the first compile. This brings the compilation count down to 2 from 3. If there is a reason for having that check I am missing, it's simple to add back in. 

Ultimately, I would like to change the way the compilation is done, because from the C# it's not obvious or clear whether your rules were actually compiled when calling CompileFromFiles as if the CheckYaraRules method may have removed your file path from its list and thus the Compile->AddFiles method will be handed an empty list, but still return you a "complete" CRules. The only way to check it hasn't gone well in the c# is to inspect the errors dictionary you get back for errors starting with "ERROR:", which is less than ideal. If you manually set up the compiler then this situation is easier to resolve as you can directly call GetErrors.

I added a Visual Studio UnitTest project for the ease of creating tests. I wasn't quite sure of the best style for this, so let me know if you dislike it and we can modify it.

If anything doesn't make sense, or you have questions, please let me know :)