### PR TITLE
Add YSScanner.ScanMemory overload to take an array of bytes.

### DIFF
--- a/YaraSharp/Scanner.cpp
+++ b/YaraSharp/Scanner.cpp
@@ -41,10 +41,25 @@ namespace YaraSharp
 			(marshal_as<std::wstring>(Path)).c_str()));
 		return matches;
 	}
+
 	List<YSMatches^>^ YSScanner::ScanMemory(uint8_t* Buffer, int Length)
 	{
 		YSException::ThrowOnError(yr_scanner_scan_mem(scanner, Buffer, Length));
 		return matches;
+	}
+
+	List<YSMatches^>^ YSScanner::ScanMemory(array<uint8_t>^ buffer)
+	{
+		if (buffer == nullptr || buffer->Length == 0)
+		{
+			return gcnew List<YSMatches^>();
+		}
+		else
+		{
+			pin_ptr<uint8_t> bufferPointer = &buffer[0];
+			YSException::ThrowOnError(yr_scanner_scan_mem(scanner, bufferPointer, buffer->Length));
+			return matches;
+		}
 	}
 
 	//	Set externals
@@ -72,7 +87,7 @@ namespace YaraSharp
 					throw gcnew NotSupportedException(String::Format("Unsupported external variable: '{0}'", VariableType->Name));
 
 				if (ExternalError != ERROR_SUCCESS)
-					YSException::ThrowOnError("(Scanner) Error during external variable intialization");
+					YSException::ThrowOnError("(Scanner) Error during external variable initialization");
 			}
 		}
 	}

--- a/YaraSharp/Scanner.h
+++ b/YaraSharp/Scanner.h
@@ -18,6 +18,7 @@ namespace YaraSharp
 		List<YSMatches^>^ ScanProcess(int pID);
 		List<YSMatches^>^ ScanFile(String^ path);
 		List<YSMatches^>^ ScanMemory(uint8_t* buffer, int length);
+		List<YSMatches^>^ ScanMemory(array<uint8_t>^ buffer);
 		int HandleScannerCallback(int message, void* data, void* context);
 	private:
 		void SetScannerCallback();


### PR DESCRIPTION
1. Added YaraSharp.YSScanner.ScanMemory overload to take an array instead of a pointer, since this is a C# wrapper, and it is expected of C# wrappers to insulate you from such constructs.

2. Added overload to class signature in header.

3. Fixed minor spelling error in exception message ('intialization' is missing an 'i').